### PR TITLE
fix POST parameter

### DIFF
--- a/localise/commands.py
+++ b/localise/commands.py
@@ -81,7 +81,7 @@ def push(conf, args):
         ))
         url = get_url(conf) + 'import/%s' % (translation['format'])
 
-        response = requests.post(url, params=params, data={'src': file})
+        response = requests.post(url, params=params, data=file)
         if response.status_code == 401:
             errors.append('Invalid API key in config file')
         elif response.status_code != 200:


### PR DESCRIPTION
The POST encoding doesn't work currently.
I talked to Tim Whitlock from Loco Support and he said it worked previously due to an unintentional fallback, which he will reinstate, however i suppose it best to fix it.