### PR TITLE
Fix utf-8 encoding on push

### DIFF
--- a/localise/commands.py
+++ b/localise/commands.py
@@ -97,7 +97,7 @@ def push(conf, args):
         for error in errors:
             print(Fore.RED + error + Style.RESET_ALL)
     else:
-        sys.exit(Fore.GREEN + 'Successfully pushed ' + str(
+        print(Fore.GREEN + 'Successfully pushed ' + str(
             len(conf['translations'])) + ' file(s) to Localise.biz!' + Style.RESET_ALL)
 
 
@@ -146,7 +146,7 @@ def pull(conf, args):
         for error in errors:
             print_error(error + Style.RESET_ALL)
     else:
-        sys.exit(Fore.GREEN + 'Successfully pulled ' + str(
+        print(Fore.GREEN + 'Successfully pulled ' + str(
             len(conf['translations'])) + ' file(s) from Localise.biz!' + Style.RESET_ALL)
 
 def print_error(message, severity=1, verbose=0):

--- a/localise/commands.py
+++ b/localise/commands.py
@@ -81,7 +81,7 @@ def push(conf, args):
         ))
         url = get_url(conf) + 'import/%s' % (translation['format'])
 
-        response = requests.post(url, params=params, data=file)
+        response = requests.post(url, params=params, data=file.encode('utf-8'))
         if response.status_code == 401:
             errors.append('Invalid API key in config file')
         elif response.status_code != 200:


### PR DESCRIPTION
Hi @marten-cz , thanks for making this tool.

But I've encoutered an error when uploading a file with chinese characters, probably about the file encoding when calling `requests.post()`

I could fix it by enforcing the encoding to be utf-8, which could be general enough for other languages.


Error trace:
```
Traceback (most recent call last):
  File "/Users/eric/.local/share/virtualenvs/i18n-7o219Dak/bin/loco-cli", line 10, in <module>
    sys.exit(main())
  File "/Users/eric/.local/share/virtualenvs/i18n-7o219Dak/lib/python3.7/site-packages/localise/localise.py", line 95, in main
    command(args)
  File "/Users/eric/.local/share/virtualenvs/i18n-7o219Dak/lib/python3.7/site-packages/localise/localise.py", line 64, in command
    push(configuration[args.project], args)
  File "/Users/eric/.local/share/virtualenvs/i18n-7o219Dak/lib/python3.7/site-packages/localise/commands.py", line 84, in push
    response = requests.post(url, params=params, data=file)
  File "/Users/eric/.local/share/virtualenvs/i18n-7o219Dak/lib/python3.7/site-packages/requests/api.py", line 116, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "/Users/eric/.local/share/virtualenvs/i18n-7o219Dak/lib/python3.7/site-packages/requests/api.py", line 60, in request
    return session.request(method=method, url=url, **kwargs)
  File "/Users/eric/.local/share/virtualenvs/i18n-7o219Dak/lib/python3.7/site-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/eric/.local/share/virtualenvs/i18n-7o219Dak/lib/python3.7/site-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/Users/eric/.local/share/virtualenvs/i18n-7o219Dak/lib/python3.7/site-packages/requests/adapters.py", line 449, in send
    timeout=timeout
  File "/Users/eric/.local/share/virtualenvs/i18n-7o219Dak/lib/python3.7/site-packages/urllib3/connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File "/Users/eric/.local/share/virtualenvs/i18n-7o219Dak/lib/python3.7/site-packages/urllib3/connectionpool.py", line 354, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/client.py", line 1229, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/client.py", line 1274, in _send_request
    body = _encode(body, 'body')
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/client.py", line 160, in _encode
    (name.title(), data[err.start:err.end], name)) from None
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 51-52: Body ('注意') is not valid Latin-1. Use body.encode('utf-8') if you want to send it encoded in UTF-8.
```